### PR TITLE
feat: export charts as a Zip file

### DIFF
--- a/superset/charts/commands/export.py
+++ b/superset/charts/commands/export.py
@@ -1,0 +1,83 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# isort:skip_file
+
+import json
+from typing import Iterator, List, Tuple
+
+import yaml
+
+from superset.commands.base import BaseCommand
+from superset.charts.commands.exceptions import ChartNotFoundError
+from superset.charts.dao import ChartDAO
+from superset.datasets.commands.export import ExportDatasetsCommand
+from superset.utils.dict_import_export import IMPORT_EXPORT_VERSION, sanitize
+from superset.models.slice import Slice
+
+
+# keys present in the standard export that are not needed
+REMOVE_KEYS = ["datasource_type", "datasource_name"]
+
+
+class ExportChartsCommand(BaseCommand):
+    def __init__(self, chart_ids: List[int]):
+        self.chart_ids = chart_ids
+
+        # this will be set when calling validate()
+        self._models: List[Slice] = []
+
+    @staticmethod
+    def export_chart(chart: Slice) -> Iterator[Tuple[str, str]]:
+        chart_slug = sanitize(chart.slice_name)
+        file_name = f"charts/{chart_slug}.yaml"
+
+        payload = chart.export_to_dict(
+            recursive=False,
+            include_parent_ref=False,
+            include_defaults=True,
+            export_uuids=True,
+        )
+        # TODO (betodealmeida): move this logic to export_to_dict once this
+        # becomes the default export endpoint
+        for key in REMOVE_KEYS:
+            del payload[key]
+        if "params" in payload:
+            try:
+                payload["params"] = json.loads(payload["params"])
+            except json.decoder.JSONDecodeError:
+                pass
+
+        payload["version"] = IMPORT_EXPORT_VERSION
+        if chart.table:
+            payload["dataset_uuid"] = str(chart.table.uuid)
+
+        file_content = yaml.safe_dump(payload, sort_keys=False)
+        yield file_name, file_content
+
+        if chart.table:
+            yield from ExportDatasetsCommand([chart.table.id]).run()
+
+    def run(self) -> Iterator[Tuple[str, str]]:
+        self.validate()
+
+        for chart in self._models:
+            yield from self.export_chart(chart)
+
+    def validate(self) -> None:
+        self._models = ChartDAO.find_by_ids(self.chart_ids)
+        if len(self._models) != len(self.chart_ids):
+            raise ChartNotFoundError()

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -45,6 +45,7 @@ screenshot_query_schema = {
         "thumb_size": width_height_schema,
     },
 }
+get_export_ids_schema = {"type": "array", "items": {"type": "integer"}}
 
 #
 # Column schema descriptions

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -347,7 +347,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @rison(get_export_ids_schema)
     def export(self, **kwargs: Any) -> Response:
-        """Export dashboards
+        """Export datasets
         ---
         get:
           description: >-

--- a/tests/charts/commands_tests.py
+++ b/tests/charts/commands_tests.py
@@ -1,0 +1,101 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from unittest.mock import patch
+
+import yaml
+
+from superset import db, security_manager
+from superset.charts.commands.exceptions import ChartNotFoundError
+from superset.charts.commands.export import ExportChartsCommand
+from superset.models.slice import Slice
+from tests.base_tests import SupersetTestCase
+
+
+class TestExportChartsCommand(SupersetTestCase):
+    @patch("superset.security.manager.g")
+    def test_export_chart_command(self, mock_g):
+        mock_g.user = security_manager.find_user("admin")
+
+        example_chart = db.session.query(Slice).all()[0]
+        command = ExportChartsCommand(chart_ids=[example_chart.id])
+        contents = dict(command.run())
+
+        expected = [
+            "charts/energy_sankey.yaml",
+            "datasets/examples/energy_usage.yaml",
+            "databases/examples.yaml",
+        ]
+        assert expected == list(contents.keys())
+
+        metadata = yaml.safe_load(contents["charts/energy_sankey.yaml"])
+        assert metadata == {
+            "slice_name": "Energy Sankey",
+            "viz_type": "sankey",
+            "params": {
+                "collapsed_fieldsets": "",
+                "groupby": ["source", "target",],
+                "metric": "sum__value",
+                "row_limit": "5000",
+                "slice_name": "Energy Sankey",
+                "viz_type": "sankey",
+            },
+            "cache_timeout": None,
+            "dataset_uuid": str(example_chart.table.uuid),
+            "uuid": str(example_chart.uuid),
+            "version": "1.0.0",
+        }
+
+    @patch("superset.security.manager.g")
+    def test_export_chart_command_no_access(self, mock_g):
+        """Test that users can't export datasets they don't have access to"""
+        mock_g.user = security_manager.find_user("gamma")
+
+        example_chart = db.session.query(Slice).all()[0]
+        command = ExportChartsCommand(chart_ids=[example_chart.id])
+        contents = command.run()
+        with self.assertRaises(ChartNotFoundError):
+            next(contents)
+
+    @patch("superset.security.manager.g")
+    def test_export_chart_command_invalid_dataset(self, mock_g):
+        """Test that an error is raised when exporting an invalid dataset"""
+        mock_g.user = security_manager.find_user("admin")
+        command = ExportChartsCommand(chart_ids=[-1])
+        contents = command.run()
+        with self.assertRaises(ChartNotFoundError):
+            next(contents)
+
+    @patch("superset.security.manager.g")
+    def test_export_chart_command_key_order(self, mock_g):
+        """Test that they keys in the YAML have the same order as export_fields"""
+        mock_g.user = security_manager.find_user("admin")
+
+        example_chart = db.session.query(Slice).all()[0]
+        command = ExportChartsCommand(chart_ids=[example_chart.id])
+        contents = dict(command.run())
+
+        metadata = yaml.safe_load(contents["charts/energy_sankey.yaml"])
+        assert list(metadata.keys()) == [
+            "slice_name",
+            "viz_type",
+            "params",
+            "cache_timeout",
+            "uuid",
+            "version",
+            "dataset_uuid",
+        ]


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Add a new endpoint to export charts as a Zip file, following https://github.com/apache/incubator-superset/issues/11167.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

Added unit tests for `ExportChartsCommand` and for the API endpoint.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: https://github.com/apache/incubator-superset/issues/11167
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [X] Introduces new feature or API
- [ ] Removes existing feature or API
